### PR TITLE
Update cmdline-tools path

### DIFF
--- a/README.md
+++ b/README.md
@@ -668,7 +668,7 @@ To learn more about Firebase Test Lab and Google Cloud SDK, please go and visit 
 
   ```console
   cat $ANDROID_SDK_ROOT/tools/source.properties | grep Pkg.Revision
-  cat $ANDROID_SDK_ROOT/cmdline-tools/tools/source.properties | grep Pkg.Revision
+  cat $ANDROID_SDK_ROOT/cmdline-tools/source.properties | grep Pkg.Revision
   cat $ANDROID_SDK_ROOT/platform-tools/source.properties | grep Pkg.Revision
   ```
 

--- a/android-sdk/Dockerfile
+++ b/android-sdk/Dockerfile
@@ -45,16 +45,16 @@ RUN cd /opt && \
 # https://developer.android.com/studio#command-tools
 ARG ANDROID_SDK_VERSION=6858069
 ENV ANDROID_SDK_ROOT /opt/android-sdk
-RUN mkdir -p ${ANDROID_SDK_ROOT}/cmdline-tools && \
+RUN mkdir -p ${ANDROID_SDK_ROOT} && \
     wget -q https://dl.google.com/android/repository/commandlinetools-linux-${ANDROID_SDK_VERSION}_latest.zip && \
-    unzip *tools*linux*.zip -d ${ANDROID_SDK_ROOT}/cmdline-tools && \
+    unzip *tools*linux*.zip -d ${ANDROID_SDK_ROOT} && \
     rm *tools*linux*.zip
 
 # set the environment variables
 ENV JAVA_HOME /usr/lib/jvm/java-${JDK_VERSION}-openjdk-amd64
 ENV GRADLE_HOME /opt/gradle
 ENV KOTLIN_HOME /opt/kotlinc
-ENV PATH ${PATH}:${GRADLE_HOME}/bin:${KOTLIN_HOME}/bin:${ANDROID_SDK_ROOT}/cmdline-tools/tools/bin:${ANDROID_SDK_ROOT}/platform-tools:${ANDROID_SDK_ROOT}/emulator
+ENV PATH ${PATH}:${GRADLE_HOME}/bin:${KOTLIN_HOME}/bin:${ANDROID_SDK_ROOT}/cmdline-tools/bin:${ANDROID_SDK_ROOT}/platform-tools:${ANDROID_SDK_ROOT}/emulator
 ENV _JAVA_OPTIONS -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap
 # WORKAROUND: for issue https://issuetracker.google.com/issues/37137213
 ENV LD_LIBRARY_PATH ${ANDROID_SDK_ROOT}/emulator/lib64:${ANDROID_SDK_ROOT}/emulator/lib64/qt/lib

--- a/android-sdk/version_inspector.sh
+++ b/android-sdk/version_inspector.sh
@@ -1,1 +1,1 @@
-cat /etc/*release | grep VERSION= && java -version && gradle -v && kotlinc -version && cat $ANDROID_SDK_ROOT/cmdline-tools/tools/source.properties && sdkmanager --list && apt list --installed | grep openssh-server
+cat /etc/*release | grep VERSION= && java -version && gradle -v && kotlinc -version && cat $ANDROID_SDK_ROOT/cmdline-tools/source.properties && sdkmanager --list && apt list --installed | grep openssh-server


### PR DESCRIPTION
Hi,

Latest bump (5 months ago to current latest as of today) has changed the cmdline-tools path location.

![image](https://user-images.githubusercontent.com/19973/98628302-6ac91280-236a-11eb-85ad-ccf0ff8a3954.png)
